### PR TITLE
Whitebox Update 2/3

### DIFF
--- a/Assets/Scenes/WhiteboxScene.unity
+++ b/Assets/Scenes/WhiteboxScene.unity
@@ -1609,6 +1609,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1842348682}
     m_Modifications:
+    - target: {fileID: -8292440801767719652, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: adjacentMines
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3039825762846663119, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_Name
       value: (2,3)
@@ -2258,6 +2262,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1842348682}
     m_Modifications:
+    - target: {fileID: -8292440801767719652, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: adjacentMines
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3039825762846663119, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_Name
       value: (1,3)

--- a/Assets/Scripts/TileBehavior.cs
+++ b/Assets/Scripts/TileBehavior.cs
@@ -29,21 +29,48 @@ public class TileBehavior : MonoBehaviour
 
     void OnMouseDown() // Handles left-click
     {
-        if (!isRevealed && !isFlagged)
+        if (!isRevealed)
         {
-            isRevealed = true;
-            if (gameObject.CompareTag("Mine"))
+            if (isFlagged)
             {
-                spriteRenderer.sprite = mineSprite;
-                textMesh.text = ""; // Clear text for mines
-                Debug.Log("Game Over! Mine clicked.");
-                // Game logic for loss here
+                if (NeighborsRevealedOrFound())
+                {
+                    isFlagged = false;
+                    isRevealed = true;
+                    RevealTile();
+                    if (gameObject.CompareTag("Mine"))
+                    {
+                        // Defuse mine
+                        gameObject.tag = "Untagged";
+                        UpdateNeighborMineCounts();
+                        Debug.Log("Mine removed at " + transform.position);
+                    }
+                    else
+                    {
+                        // False flag: clear flag and reveal
+                        Debug.Log("False flag revealed at " + transform.position + ", Adjacent Mines: " + adjacentMines);
+                    }
+                }
+                else
+                {
+                    Debug.Log("Cannot click flagged tile at " + transform.position + ": not all neighbors are revealed or flagged.");
+                }
             }
             else
             {
-                spriteRenderer.sprite = revealedSprite;
-                textMesh.text = adjacentMines > 0 ? adjacentMines.ToString() : ""; // Show number if > 0
-                Debug.Log("Tile revealed: " + transform.position + ", Adjacent Mines: " + adjacentMines);
+                isRevealed = true;
+                if (gameObject.CompareTag("Mine"))
+                {
+                    spriteRenderer.sprite = mineSprite;
+                    textMesh.text = ""; // Clear text for mines
+                    Debug.Log("Game Over! Mine clicked.");
+                    // Game logic for loss here
+                }
+                else
+                {
+                    RevealTile();
+                    Debug.Log("Tile revealed: " + transform.position + ", Adjacent Mines: " + adjacentMines);
+                }
             }
         }
     }
@@ -57,5 +84,99 @@ public class TileBehavior : MonoBehaviour
             textMesh.text = ""; // Clear text when flagging/unflagging
             Debug.Log(isFlagged ? "Tile flagged" : "Tile unflagged");
         }
+    }
+
+    void RevealTile()
+    {
+        spriteRenderer.sprite = revealedSprite;
+        if (textMesh != null)
+        {
+            textMesh.text = adjacentMines > 0 ? adjacentMines.ToString() : ""; // Show number if > 0
+        }
+    }
+
+    private bool NeighborsRevealedOrFound()
+    {
+        Vector2[] offsets = DefineNeighborOffsets();
+
+        foreach (Vector2 offset in offsets)
+        {
+            Vector2 neighborPos = new Vector2(transform.position.x, transform.position.y) + offset;
+            GameObject neighbor = FindTileAtPosition(neighborPos);
+            if (neighbor != null)
+            {
+                TileBehavior neighborTile = neighbor.GetComponent<TileBehavior>();
+                if (neighborTile != null && !neighborTile.isRevealed && !neighborTile.isFlagged)
+                {
+                    return false; // Neighbor is neither revealed nor flagged
+                }
+            }
+        }
+
+        return true; // All neighbors are either revealed or flagged
+    }
+
+    private GameObject FindTileAtPosition(Vector2 pos)
+    {
+        pos = new Vector2(Mathf.Round(pos.x), Mathf.Round(pos.y));
+        GameObject[] tiles = GameObject.FindGameObjectsWithTag("Untagged");
+        foreach (GameObject tile in tiles)
+        {
+            Vector2 tilePos = new Vector2(Mathf.Round(tile.transform.position.x), Mathf.Round(tile.transform.position.y));
+            if (tilePos == pos)
+            {
+                Debug.Log("Found Untagged tile at " + pos);
+                return tile;
+            }
+        }
+        tiles = GameObject.FindGameObjectsWithTag("Mine");
+        foreach (GameObject tile in tiles)
+        {
+            Vector2 tilePos = new Vector2(Mathf.Round(tile.transform.position.x), Mathf.Round(tile.transform.position.y));
+            if (tilePos == pos)
+            {
+                Debug.Log("Found Mine tile at " + pos);
+                return tile;
+            }
+        }
+        Debug.LogWarning("No tile found at " + pos);
+        return null;
+    }
+
+    private void UpdateNeighborMineCounts()
+    {
+        Vector2[] offsets = DefineNeighborOffsets();
+
+        foreach (Vector2 offset in offsets)
+        {
+            Vector2 neighborPos = new Vector2(transform.position.x, transform.position.y) + offset;
+            GameObject neighbor = FindTileAtPosition(neighborPos);
+            if (neighbor != null)
+            {
+                TileBehavior neighborTile = neighbor.GetComponent<TileBehavior>();
+                if (neighborTile != null && !neighborTile.CompareTag("Mine"))
+                {
+                    neighborTile.adjacentMines = Mathf.Max(0, neighborTile.adjacentMines - 1);
+                    // Update text if neighbor is revealed
+                    if (neighborTile.isRevealed && neighborTile.textMesh != null)
+                    {
+                        neighborTile.textMesh.text = neighborTile.adjacentMines > 0 ? neighborTile.adjacentMines.ToString() : "";
+                    }
+                }
+            }
+        }
+    }
+
+    private Vector2[] DefineNeighborOffsets()
+    {
+        Vector2[] offsets = new Vector2[]
+        {
+            new Vector2(-1, 0), new Vector2(1, 0),
+            new Vector2(0, 1), new Vector2(0, -1),
+            new Vector2(-1, 1), new Vector2(1, 1),
+            new Vector2(-1, -1), new Vector2(1, -1)
+        };
+
+        return offsets;
     }
 }


### PR DESCRIPTION
-Added the ability to defuse tiles by left clicking a flagged tile.
  -In order to defuse a tile, all of its neighbors must be either revealed or flagged.
  -Defusing a tile removes the mine from the board and reveals the tile as normal.
  -False flags (flagged tiles that actually do not have a mine) will be revealed as normal.

Known Issues:
-When a mine is defused, neighboring tile's bomb counts do not update as intended.