### PR TITLE
Whitebox Bug Fixes

### DIFF
--- a/Assets/Scenes/WhiteboxScene.unity
+++ b/Assets/Scenes/WhiteboxScene.unity
@@ -137,15 +137,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -153,7 +153,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -227,15 +227,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -243,7 +243,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -3
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -312,15 +312,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -328,7 +328,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -461,7 +461,7 @@ Transform:
   m_GameObject: {fileID: 330585543}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalPosition: {x: 2, y: -1, z: -10}
   m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
   m_ConstrainProportionsScale: 1
   m_Children: []
@@ -534,15 +534,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -550,7 +550,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -736,15 +736,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -752,7 +752,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -3
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -818,6 +818,70 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
   m_PrefabInstance: {fileID: 1051528965}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &728804253
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3039825762846663119, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: m_Name
+      value: Tile
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 17.207874
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.29427636
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1848980061233795497, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
 --- !u!1001 &768016253
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -836,15 +900,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -852,7 +916,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -965,15 +1029,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -981,7 +1045,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1129,15 +1193,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1145,7 +1209,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1209,15 +1273,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1225,7 +1289,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1289,15 +1353,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1305,7 +1369,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1369,15 +1433,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1385,7 +1449,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1454,15 +1518,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1470,7 +1534,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1534,15 +1598,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1550,7 +1614,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1623,15 +1687,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1639,7 +1703,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1718,15 +1782,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1734,7 +1798,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -3
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1808,15 +1872,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1824,7 +1888,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1900,7 +1964,7 @@ Transform:
   m_GameObject: {fileID: 1842348681}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.32473, y: -1.01889, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1940,15 +2004,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1956,7 +2020,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -3
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2018,7 +2082,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!212 &1965635503
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -2083,7 +2147,7 @@ Transform:
   m_GameObject: {fileID: 1965635502}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 1, z: 0}
+  m_LocalPosition: {x: 2.5, y: -1, z: 0}
   m_LocalScale: {x: 28, y: 13.000199, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2107,15 +2171,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2123,7 +2187,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -3
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2187,15 +2251,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2203,7 +2267,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2276,15 +2340,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.5
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2292,7 +2356,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 6623872570328400998, guid: d4b46de029bac644e9addada2d830ca5, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2353,3 +2417,4 @@ SceneRoots:
   - {fileID: 952424289}
   - {fileID: 1965635504}
   - {fileID: 1842348682}
+  - {fileID: 728804253}

--- a/Assets/Scripts/TileBehavior.cs
+++ b/Assets/Scripts/TileBehavior.cs
@@ -1,6 +1,7 @@
 using TMPro;
 using UnityEngine;
 
+[System.Obsolete]
 public class TileBehavior : MonoBehaviour
 {
     private SpriteRenderer spriteRenderer;
@@ -98,6 +99,7 @@ public class TileBehavior : MonoBehaviour
     private bool NeighborsRevealedOrFound()
     {
         Vector2[] offsets = DefineNeighborOffsets();
+        Debug.Log("Checking neighbors for tile at " + transform.position);
 
         foreach (Vector2 offset in offsets)
         {
@@ -106,37 +108,44 @@ public class TileBehavior : MonoBehaviour
             if (neighbor != null)
             {
                 TileBehavior neighborTile = neighbor.GetComponent<TileBehavior>();
-                if (neighborTile != null && !neighborTile.isRevealed && !neighborTile.isFlagged)
+                if (neighborTile != null)
                 {
-                    return false; // Neighbor is neither revealed nor flagged
+                    if (!neighborTile.isRevealed && !neighborTile.isFlagged)
+                    {
+                        Debug.Log("Neighbor at " + neighborPos + " is neither revealed nor flagged.");
+                        return false; // Neighbor is neither revealed nor flagged
+                    }
+                    else
+                    {
+                        Debug.Log("Neighbor at " + neighborPos + " is " + (neighborTile.isRevealed ? "revealed" : "flagged"));
+                    }
                 }
+            }
+            else
+            {
+                Debug.Log("No neighbor found at " + neighborPos + "; treating as valid (edge case).");
             }
         }
 
-        return true; // All neighbors are either revealed or flagged
+        Debug.Log("All neighbors at " + transform.position + " are revealed or flagged.");
+        return true; // All neighbors are either revealed, flagged, or non-existent (edge of board)
     }
 
     private GameObject FindTileAtPosition(Vector2 pos)
     {
         pos = new Vector2(Mathf.Round(pos.x), Mathf.Round(pos.y));
-        GameObject[] tiles = GameObject.FindGameObjectsWithTag("Untagged");
-        foreach (GameObject tile in tiles)
+        GameObject[] allTiles = GameObject.FindObjectsOfType<GameObject>(); // Get all GameObjects
+        foreach (GameObject tile in allTiles)
         {
-            Vector2 tilePos = new Vector2(Mathf.Round(tile.transform.position.x), Mathf.Round(tile.transform.position.y));
-            if (tilePos == pos)
+            TileBehavior tileBehavior = tile.GetComponent<TileBehavior>();
+            if (tileBehavior != null)
             {
-                Debug.Log("Found Untagged tile at " + pos);
-                return tile;
-            }
-        }
-        tiles = GameObject.FindGameObjectsWithTag("Mine");
-        foreach (GameObject tile in tiles)
-        {
-            Vector2 tilePos = new Vector2(Mathf.Round(tile.transform.position.x), Mathf.Round(tile.transform.position.y));
-            if (tilePos == pos)
-            {
-                Debug.Log("Found Mine tile at " + pos);
-                return tile;
+                Vector2 tilePos = new Vector2(Mathf.Round(tile.transform.position.x), Mathf.Round(tile.transform.position.y));
+                if (tilePos == pos)
+                {
+                    Debug.Log("Found tile at " + pos + " with tag " + tile.tag);
+                    return tile;
+                }
             }
         }
         Debug.LogWarning("No tile found at " + pos);
@@ -146,6 +155,7 @@ public class TileBehavior : MonoBehaviour
     private void UpdateNeighborMineCounts()
     {
         Vector2[] offsets = DefineNeighborOffsets();
+        Debug.Log("Updating neighbor mine counts for tile at " + transform.position);
 
         foreach (Vector2 offset in offsets)
         {
@@ -154,10 +164,10 @@ public class TileBehavior : MonoBehaviour
             if (neighbor != null)
             {
                 TileBehavior neighborTile = neighbor.GetComponent<TileBehavior>();
-                if (neighborTile != null && !neighborTile.CompareTag("Mine"))
+                if (neighborTile != null)
                 {
                     neighborTile.adjacentMines = Mathf.Max(0, neighborTile.adjacentMines - 1);
-                    // Update text if neighbor is revealed
+                    Debug.Log("Updated neighbor at " + neighborPos + " (Tag: " + neighbor.tag + "): adjacentMines = " + neighborTile.adjacentMines);
                     if (neighborTile.isRevealed && neighborTile.textMesh != null)
                     {
                         neighborTile.textMesh.text = neighborTile.adjacentMines > 0 ? neighborTile.adjacentMines.ToString() : "";

--- a/UserSettings/Layouts/default-6000.dwlt
+++ b/UserSettings/Layouts/default-6000.dwlt
@@ -8,30 +8,6 @@ MonoBehaviour:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12004, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_PixelRect:
-    serializedVersion: 2
-    x: 8
-    y: 31
-    width: 1904
-    height: 1041
-  m_ShowMode: 0
-  m_Title: Project Settings
-  m_RootView: {fileID: 4}
-  m_MinSize: {x: 310, y: 226}
-  m_MaxSize: {x: 4000, y: 4026}
-  m_Maximized: 0
---- !u!114 &2
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12004, guid: 0000000000000000e000000000000000, type: 0}
   m_Name: 
@@ -44,62 +20,11 @@ MonoBehaviour:
     height: 1037
   m_ShowMode: 4
   m_Title: Game
-  m_RootView: {fileID: 12}
+  m_RootView: {fileID: 9}
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
   m_Maximized: 1
---- !u!114 &3
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: ProjectSettingsWindow
-  m_EditorClassIdentifier: 
-  m_Children: []
-  m_Position:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1904
-    height: 1041
-  m_MinSize: {x: 310, y: 226}
-  m_MaxSize: {x: 4000, y: 4026}
-  m_ActualView: {fileID: 17}
-  m_Panes:
-  - {fileID: 17}
-  m_Selected: 0
-  m_LastSelected: 0
---- !u!114 &4
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12010, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Children:
-  - {fileID: 3}
-  m_Position:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1904
-    height: 1041
-  m_MinSize: {x: 310, y: 226}
-  m_MaxSize: {x: 4000, y: 4026}
-  vertical: 0
-  controlID: 529
-  draggingID: 0
---- !u!114 &5
+--- !u!114 &2
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -118,14 +43,14 @@ MonoBehaviour:
     y: 0
     width: 378
     height: 305
-  m_MinSize: {x: 201, y: 226}
-  m_MaxSize: {x: 4001, y: 4026}
-  m_ActualView: {fileID: 22}
+  m_MinSize: {x: 200, y: 200}
+  m_MaxSize: {x: 4000, y: 4000}
+  m_ActualView: {fileID: 18}
   m_Panes:
-  - {fileID: 22}
+  - {fileID: 18}
   m_Selected: 0
   m_LastSelected: 0
---- !u!114 &6
+--- !u!114 &3
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -138,8 +63,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 5}
-  - {fileID: 11}
+  - {fileID: 2}
+  - {fileID: 8}
   m_Position:
     serializedVersion: 2
     x: 0
@@ -149,9 +74,9 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 50}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 223
+  controlID: 28
   draggingID: 0
---- !u!114 &7
+--- !u!114 &4
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -172,12 +97,12 @@ MonoBehaviour:
     height: 307
   m_MinSize: {x: 101, y: 126}
   m_MaxSize: {x: 4001, y: 4026}
-  m_ActualView: {fileID: 25}
+  m_ActualView: {fileID: 21}
   m_Panes:
-  - {fileID: 25}
+  - {fileID: 21}
   m_Selected: 0
   m_LastSelected: 0
---- !u!114 &8
+--- !u!114 &5
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -190,8 +115,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 10}
   - {fileID: 7}
+  - {fileID: 4}
   m_Position:
     serializedVersion: 2
     x: 1401
@@ -201,9 +126,9 @@ MonoBehaviour:
   m_MinSize: {x: 100, y: 100}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 268
+  controlID: 90
   draggingID: 0
---- !u!114 &9
+--- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -216,8 +141,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 15}
-  - {fileID: 8}
+  - {fileID: 12}
+  - {fileID: 5}
   m_Position:
     serializedVersion: 2
     x: 0
@@ -227,9 +152,9 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 100}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 267
+  controlID: 17
   draggingID: 0
---- !u!114 &10
+--- !u!114 &7
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -248,14 +173,14 @@ MonoBehaviour:
     y: 0
     width: 519
     height: 674
-  m_MinSize: {x: 276, y: 76}
-  m_MaxSize: {x: 4001, y: 4026}
-  m_ActualView: {fileID: 21}
+  m_MinSize: {x: 275, y: 50}
+  m_MaxSize: {x: 4000, y: 4000}
+  m_ActualView: {fileID: 17}
   m_Panes:
-  - {fileID: 21}
+  - {fileID: 17}
   m_Selected: 0
   m_LastSelected: 1
---- !u!114 &11
+--- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -276,14 +201,14 @@ MonoBehaviour:
     height: 305
   m_MinSize: {x: 232, y: 276}
   m_MaxSize: {x: 10002, y: 10026}
-  m_ActualView: {fileID: 20}
+  m_ActualView: {fileID: 16}
   m_Panes:
-  - {fileID: 20}
-  - {fileID: 19}
-  - {fileID: 18}
+  - {fileID: 16}
+  - {fileID: 15}
+  - {fileID: 14}
   m_Selected: 0
   m_LastSelected: 2
---- !u!114 &12
+--- !u!114 &9
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -296,9 +221,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 13}
-  - {fileID: 9}
-  - {fileID: 14}
+  - {fileID: 10}
+  - {fileID: 6}
+  - {fileID: 11}
   m_Position:
     serializedVersion: 2
     x: 0
@@ -311,7 +236,7 @@ MonoBehaviour:
   m_TopViewHeight: 36
   m_UseBottomView: 1
   m_BottomViewHeight: 20
---- !u!114 &13
+--- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -333,7 +258,7 @@ MonoBehaviour:
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
   m_LastLoadedLayoutName: 
---- !u!114 &14
+--- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -354,7 +279,7 @@ MonoBehaviour:
     height: 20
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
---- !u!114 &15
+--- !u!114 &12
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -367,8 +292,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 16}
-  - {fileID: 6}
+  - {fileID: 13}
+  - {fileID: 3}
   m_Position:
     serializedVersion: 2
     x: 0
@@ -378,9 +303,9 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 222
+  controlID: 18
   draggingID: 0
---- !u!114 &16
+--- !u!114 &13
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -401,77 +326,13 @@ MonoBehaviour:
     height: 676
   m_MinSize: {x: 201, y: 226}
   m_MaxSize: {x: 4001, y: 4026}
-  m_ActualView: {fileID: 23}
+  m_ActualView: {fileID: 19}
   m_Panes:
-  - {fileID: 23}
-  - {fileID: 24}
+  - {fileID: 19}
+  - {fileID: 20}
   m_Selected: 0
   m_LastSelected: 1
---- !u!114 &17
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 13854, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MinSize: {x: 310, y: 200}
-  m_MaxSize: {x: 4000, y: 4000}
-  m_TitleContent:
-    m_Text: Project Settings
-    m_Image: {fileID: -5712115415447495865, guid: 0000000000000000d000000000000000, type: 0}
-    m_Tooltip: 
-    m_TextWithWhitespace: "Project Settings\u200B"
-  m_Pos:
-    serializedVersion: 2
-    x: 0
-    y: 26
-    width: 1904
-    height: 1015
-  m_SerializedDataModeController:
-    m_DataMode: 0
-    m_PreferredDataMode: 0
-    m_SupportedDataModes: 
-    isAutomatic: 1
-  m_ViewDataDictionary: {fileID: 0}
-  m_OverlayCanvas:
-    m_LastAppliedPresetName: Default
-    m_SaveData: []
-    m_ContainerData: []
-    m_OverlaysVisible: 1
-  m_PosLeft: {x: 0, y: 0}
-  m_PosRight: {x: 0, y: 840}
-  m_Scope: 1
-  m_SplitterPos: 150
-  m_SearchText: 
-  m_TreeViewState:
-    scrollPos: {x: 0, y: 0}
-    m_SelectedIDs: 4dcf9b58
-    m_LastClickedID: 1486606157
-    m_ExpandedIDs: 000000007f0eae07e594f01ac53aba5a
-    m_RenameOverlay:
-      m_UserAcceptedRename: 0
-      m_Name: 
-      m_OriginalName: 
-      m_EditFieldRect:
-        serializedVersion: 2
-        x: 0
-        y: 0
-        width: 0
-        height: 0
-      m_UserData: 0
-      m_IsWaitingForDelay: 0
-      m_IsRenaming: 0
-      m_OriginalEventType: 11
-      m_IsRenamingFilename: 0
-      m_TrimLeadingAndTrailingWhitespace: 0
-      m_ClientGUIView: {fileID: 0}
-    m_SearchString: 
---- !u!114 &18
+--- !u!114 &14
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -543,7 +404,7 @@ MonoBehaviour:
   m_CurrentEditor: 1
   m_LayerEditor:
     m_SelectedLayerIndex: 0
---- !u!114 &19
+--- !u!114 &15
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -581,8 +442,8 @@ MonoBehaviour:
     m_OverlaysVisible: 1
   m_LockTracker:
     m_IsLocked: 0
-  m_LastSelectedObjectID: -17568
---- !u!114 &20
+  m_LastSelectedObjectID: -1306
+--- !u!114 &16
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -603,8 +464,8 @@ MonoBehaviour:
     m_TextWithWhitespace: "Project\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 379
-    y: 24
+    x: 378
+    y: 755
     width: 1021
     height: 279
   m_SerializedDataModeController:
@@ -647,7 +508,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: b2b20000
     m_LastClickedID: 45746
-    m_ExpandedIDs: 0000000074aa000076aa000078aa00007aaa0000
+    m_ExpandedIDs: 0000000078aa00007aaa00007caa00007eaa0000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -673,10 +534,10 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
   m_AssetTreeState:
-    scrollPos: {x: 0, y: 39}
+    scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 0000000074aa000076aa000078aa00007aaa0000
+    m_ExpandedIDs: ffffffff0000000078aa00007aaa00007caa00007eaa0000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -693,7 +554,7 @@ MonoBehaviour:
       m_OriginalEventType: 11
       m_IsRenamingFilename: 1
       m_TrimLeadingAndTrailingWhitespace: 0
-      m_ClientGUIView: {fileID: 11}
+      m_ClientGUIView: {fileID: 8}
     m_SearchString: 
     m_CreateAssetUtility:
       m_EndAction: {fileID: 0}
@@ -734,7 +595,7 @@ MonoBehaviour:
     m_GridSize: 64
   m_SkipHiddenPackages: 0
   m_DirectoriesAreaWidth: 207
---- !u!114 &21
+--- !u!114 &17
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -755,8 +616,8 @@ MonoBehaviour:
     m_TextWithWhitespace: "Inspector\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 1
-    y: 24
+    x: 1401
+    y: 79
     width: 518
     height: 648
   m_SerializedDataModeController:
@@ -783,7 +644,7 @@ MonoBehaviour:
   m_LockTracker:
     m_IsLocked: 0
   m_PreviewWindow: {fileID: 0}
---- !u!114 &22
+--- !u!114 &18
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -805,7 +666,7 @@ MonoBehaviour:
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 24
+    y: 755
     width: 377
     height: 279
   m_SerializedDataModeController:
@@ -821,10 +682,10 @@ MonoBehaviour:
     m_OverlaysVisible: 1
   m_SceneHierarchy:
     m_TreeViewState:
-      scrollPos: {x: 0, y: 0}
+      scrollPos: {x: 0, y: 174}
       m_SelectedIDs: 
       m_LastClickedID: 0
-      m_ExpandedIDs: 18fbffff
+      m_ExpandedIDs: b8f4ffff18fbffff18a90000
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -841,7 +702,7 @@ MonoBehaviour:
         m_OriginalEventType: 11
         m_IsRenamingFilename: 0
         m_TrimLeadingAndTrailingWhitespace: 0
-        m_ClientGUIView: {fileID: 5}
+        m_ClientGUIView: {fileID: 2}
       m_SearchString: 
     m_ExpandedScenes: []
     m_CurrenRootInstanceID: 0
@@ -849,7 +710,7 @@ MonoBehaviour:
       m_IsLocked: 0
     m_CurrentSortingName: TransformSorting
   m_WindowGUID: 4c969a2b90040154d917609493e03593
---- !u!114 &23
+--- !u!114 &19
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -871,7 +732,7 @@ MonoBehaviour:
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 24
+    y: 79
     width: 1400
     height: 650
   m_SerializedDataModeController:
@@ -1428,9 +1289,9 @@ MonoBehaviour:
   m_AudioPlay: 0
   m_DebugDrawModesUseInteractiveLightBakingData: 0
   m_Position:
-    m_Target: {x: -1.8049939, y: 2.0385976, z: -8.598204}
+    m_Target: {x: 0.6645954, y: -1.3467593, z: -8.5508375}
     speed: 2
-    m_Value: {x: -1.8049939, y: 2.0385976, z: -8.598204}
+    m_Value: {x: 0.6645954, y: -1.3467593, z: -8.5508375}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -1480,9 +1341,9 @@ MonoBehaviour:
     speed: 2
     m_Value: {x: 0, y: 0, z: 0, w: 1}
   m_Size:
-    m_Target: 7.524429
+    m_Target: 3.3642983
     speed: 2
-    m_Value: 7.524429
+    m_Value: 3.3642983
   m_Ortho:
     m_Target: 1
     speed: 2
@@ -1503,7 +1364,7 @@ MonoBehaviour:
   m_LastSceneViewRotation: {x: -0.08717229, y: 0.89959055, z: -0.21045254, w: -0.3726226}
   m_LastSceneViewOrtho: 0
   m_Viewpoint:
-    m_SceneView: {fileID: 23}
+    m_SceneView: {fileID: 19}
     m_CameraOverscanSettings:
       m_Opacity: 50
       m_Scale: 1
@@ -1516,7 +1377,7 @@ MonoBehaviour:
     name: Contributors / Receivers
     section: Lighting
   m_ViewIsLockedToObject: 0
---- !u!114 &24
+--- !u!114 &20
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1617,7 +1478,7 @@ MonoBehaviour:
   m_XRRenderMode: 0
   m_RenderTexture: {fileID: 0}
   m_showToolbar: 1
---- !u!114 &25
+--- !u!114 &21
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1638,8 +1499,8 @@ MonoBehaviour:
     m_TextWithWhitespace: "Console\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 1
-    y: 698
+    x: 1401
+    y: 753
     width: 518
     height: 281
   m_SerializedDataModeController:


### PR DESCRIPTION
-Fixed a bug where tiles were in improper positions (ex: positioned at Y=2.9999998 instead of Y=3). 
-Fixed a bug where tiles' neighboring mine counts would not update. 
-Fixed a bug where a flagged tile could be removed despite not meeting the criteria.